### PR TITLE
fixed undefined variable in createMangoUser

### DIFF
--- a/Helper/UserHelper.php
+++ b/Helper/UserHelper.php
@@ -38,6 +38,7 @@ class UserHelper
 
     public function createMangoUser(UserInterface $user)
     {
+        $birthdate = null;
         if ($user->getBirthDate() instanceof \Datetime) {
             $birthdate = $user->getBirthDate()->getTimestamp();
         }


### PR DESCRIPTION
when getBirthDate does not return a datetime object

so that it fails at the API call, giving a better explanation of what's wrong