### PR TITLE
[Transaction] set method getId public

### DIFF
--- a/Entity/Transaction.php
+++ b/Entity/Transaction.php
@@ -133,7 +133,7 @@ class Transaction implements TransactionInterface
      *
      * @return int
      */
-    protected function getId()
+    public function getId()
     {
         return $this->id;
     }


### PR DESCRIPTION
Hi,
Is there any reason for letting the `getId()` method protected?
Thank you