### PR TITLE
[Transaction] Remove @ORM\Entity

### DIFF
--- a/Entity/Transaction.php
+++ b/Entity/Transaction.php
@@ -9,7 +9,6 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
  * Transaction.
  *
  * @ORM\MappedSuperclass
- * @ORM\Entity
  */
 class Transaction implements TransactionInterface
 {


### PR DESCRIPTION
Following Doctrine's documentation (http://docs.doctrine-project.org/en/latest/reference/inheritance-mapping.html)
> a mapped superclass cannot be an entity

otherwise extending the class leads to errors such as described here : http://stackoverflow.com/questions/21536634/doctrine-query-crashing
There is hence an architecture choice to be made : either keep the `@ORM\MappedSuperclass` annotation or remove it.
I personally think it is the bundle's user responsibility to extend the class should he need to persist the object, this is why I removed the `@ORM\Entity` annotation.