### PR TITLE
duplicate troopers_mangopay.payment_out_helper

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -70,11 +70,6 @@ services:
         arguments:
             - "@troopers_mangopay.mango_api"
 
-    troopers_mangopay.payment_out_helper:
-        class: "%troopers_mangopay.payment_out_helper.class%"
-        arguments:
-            - "@troopers_mangopay.mango_api"
-
     troopers_mangopay.form.card:
         class: "%troopers_mangopay.form.card%"
         tags:


### PR DESCRIPTION
in config.yml , causing deprecation warning in symfony3

oops forgot one 