### PR TITLE
fix composer version limiter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "~5.3|~7",
         "symfony/framework-bundle": ">=2.3",
         "mangopay/php-sdk-v2": ">=2.0",
-        "stof/doctrine-extensions-bundle": "~1.2.0",
-        "troopers/ajax-bundle": "~1.2.1"
+        "stof/doctrine-extensions-bundle": "~1.2",
+        "troopers/ajax-bundle": "~1.2"
     },
 
     "autoload": {


### PR DESCRIPTION
allow last update for ajax-bundle for firefox fix https://github.com/Troopers/AjaxBundle/releases/tag/1.3.1