### PR TITLE
Fix symfony/config 4.2+ deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,9 +16,15 @@ class Configuration implements ConfigurationInterface
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
-    {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('troopers_mangopay');
+    {   
+        $treeBuilder = new TreeBuilder('troopers_mangopay');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('troopers_mangopay');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

as well as:

> The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "troopers_mangopay" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.